### PR TITLE
Refactor to use a cached item in checking expiration. This prevents a race condition when checking an item twice consecutively returns nil the second time.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "Gemfile.lock" }}
+          - v1-dependencies-{{ checksum "semaphore.gemspec" }}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
@@ -37,7 +37,7 @@ jobs:
       - save_cache:
           paths:
             - ./vendor/bundle
-          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+          key: v1-dependencies-{{ checksum "semaphore.gemspec" }}
 
       # run tests!
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,13 +10,14 @@ jobs:
        - image: circleci/ruby:2.5.0
          environment:
            AWS_REGION: us-east-1
+           BUNDLE_JOBS: 3
+           BUNDLE_RETRY: 3
+           BUNDLE_PATH: vendor/bundle
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
       # - image: circleci/postgres:9.4
-
-    working_directory: ~/repo
 
     steps:
       - checkout

--- a/lib/semaphore/stores/dynamodb_store.rb
+++ b/lib/semaphore/stores/dynamodb_store.rb
@@ -12,7 +12,7 @@ module Semaphore
       end
 
       def locked?
-        if item && expires_at && Time.now >= expires_at
+        if expired?
           unlock!
           false
         else
@@ -42,9 +42,11 @@ module Semaphore
         true
       end
 
-      def expires_at
+      def expired?
         saved_item = item
-        Time.at(saved_item['expires_at']) if saved_item && saved_item['expires_at']
+        return false unless saved_item
+        expires_at = Time.at(saved_item['expires_at']) if saved_item['expires_at']
+        expires_at && Time.now >= expires_at
       end
 
       private

--- a/lib/semaphore/stores/memory_store.rb
+++ b/lib/semaphore/stores/memory_store.rb
@@ -1,14 +1,14 @@
 module Semaphore
   module Stores
     class MemoryStore
-      attr_reader :name, :expires_at
+      attr_reader :name
 
       def initialize(name)
         @name = name
       end
 
       def locked?
-        if @locked && @expires_at && Time.now >= @expires_at
+        if expired?
           unlock!
           false
         else
@@ -26,6 +26,10 @@ module Semaphore
         @locked = false
         @expires_at = nil
         true
+      end
+
+      def expired?
+        @locked && @expires_at && Time.now >= @expires_at
       end
     end
   end

--- a/spec/semaphore/stores/dynamodb_store_spec.rb
+++ b/spec/semaphore/stores/dynamodb_store_spec.rb
@@ -16,13 +16,15 @@ describe Semaphore::Stores::DynamodbStore do
 
   it 'should lock with expiration' do
     subject.lock!(expires_in: 1)
-    expect(subject.expires_at.to_f).to be_within(1.2).of(Time.now.to_f)
+    expect(subject.expired?).to eq(false)
+    sleep 1
+    expect(subject.expired?).to eq(true)
   end
 
   it 'should unlock and clear the expiration' do
     subject.lock!(expires_in: 1)
     subject.unlock!
-    expect(subject.expires_at).to be_nil
+    expect(subject.expired?).to eq(false)
   end
 
   it 'should clear unlock after expiration' do

--- a/spec/semaphore/stores/memory_store_spec.rb
+++ b/spec/semaphore/stores/memory_store_spec.rb
@@ -14,13 +14,15 @@ describe Semaphore::Stores::MemoryStore do
 
   it 'should lock with expiration' do
     subject.lock!(expires_in: 1)
-    expect(subject.expires_at.to_f).to be_within(1.2).of(Time.now.to_f)
+    expect(subject.expired?).to eq(false)
+    sleep 1
+    expect(subject.expired?).to eq(true)
   end
 
   it 'should unlock and clear the expiration' do
     subject.lock!(expires_in: 1)
     subject.unlock!
-    expect(subject.expires_at).to be_nil
+    expect(subject.expired?).to eq(false)
   end
 
   it 'should clear unlock after expiration' do


### PR DESCRIPTION
@andrewkatz, this fixes the issue in https://circleci.com/gh/greenbits/herer-api/10806